### PR TITLE
Strip special Unix symbols from the book title

### DIFF
--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -54,7 +54,7 @@ end
 function PocketbookSync:getTitle()
     local props = self.view.document:getProps()
 
-    return props.title
+    return string.gsub(props.title, ":\/", "")
 end
 
 function PocketbookSync:onPageUpdate(page)


### PR DESCRIPTION
Hopefully, I've got the syntax right.

Closes #4