### PR TITLE
correct function name isPocketBook

### DIFF
--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -1,6 +1,6 @@
 local Device = require("device")
 
-if not Device:isPocketbook() then
+if not Device:isPocketBook() then
     return { disabled = true, }
 end
 


### PR DESCRIPTION
fixes: Error when loading plugins/pocketbooksync.koplugin/main.lua plugins/pocketbooksync.koplugin/main.lua:3: attempt to call method 'isPocketbook' (a nil value)