### PR TITLE
Skip hidden flows (non-linear fragments) in the progress bar

### DIFF
--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -59,6 +59,17 @@ function PocketbookSync:prepareSync()
     local status = summary and summary.status
     local completed = (status == "complete" or page == totalPages) and 1 or 0
 
+    -- hide the progress bar if we're on the title/cover page
+    --
+    -- we'll never set cpage=1 so the progress bar will seem to jump a bit at
+    -- the start of a book, but there's no nice way to fix that: to use the
+    -- full range, we'd need to map pages 2 to last-1 to cpages 1 to last-1,
+    -- and that always skips one position; skipping the first one is the least
+    -- surprising behaviour
+    if page == 1 then
+        page = 0
+    end
+
     local data = {
         folder = folder,
         file = file,

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -57,7 +57,7 @@ function PocketbookSync:prepareSync()
         totalPages = totalPages,
         page = page,
         completed = completed,
-        time = os.time(os.date("!*t")),
+        time = os.time(),
     }
     return data
 end


### PR DESCRIPTION
A user reported that when reading a book with hidden flows (non-linear fragments), the progress bar on PocketBook home screen never reaches 100% - https://www.mobileread.com/forums/showpost.php?p=4371306&postcount=30

To solve this, instead of using the total number of pages, we use the number of pages in the main flow (actually, current flow, and if that is not the main one, we skip the sync completely).

The implementation is inspired by https://github.com/koreader/koreader/blob/2e2ca76a03ba255764bb9b8e6cc81a4bd501a3b3/plugins/statistics.koplugin/main.lua#L1620-L1630
Note that we don't need to check hasHiddenFlows as the flow-aware methods of CreDocument handle flow-less documents as well.
