### PR TITLE
Remove deleted book from Pocketbook library

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ KOReader and PBReader.
 For further information, read the corresponding thread on MobileRead:
 https://www.mobileread.com/forums/showthread.php?t=354026
 
+## Fork Changes
+
+This custom fork has following changes:
+
+* After deleting the file, it's also deleted from the Pocketbook database, so there's no ghost entries on the home screen for the removed books.
+* Plugin keeps the open page snapshot, the same way the built-in reader does it, so you can configure the device to display it during the power up process.

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -123,11 +123,11 @@ function PocketbookSync:getBookId(folder, file)
             LIMIT 1
         ]]
         local stmt = pocketbookDbConn:prepare(sql)
-        local row = stmt:reset():bind(data.folder, data.file):step()
+        local row = stmt:reset():bind(folder, file):step()
         stmt:close()
 
         if row == nil then
-            logger.info("Pocketbook Sync: Book id for " .. data.folder .. "/" .. data.file .. " not found")
+            logger.info("Pocketbook Sync: Book id for " .. folder .. "/" .. file .. " not found")
             return
         end
         bookIds[cacheKey] = row[1]

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -73,7 +73,7 @@ local function DeleteFileBook(path)
 
     local sql = [[
             DELETE FROM books_impl
-            WHERE book_id=?
+            WHERE book_id = :book_id
         ]]
     local stmt = pocketbookDbConn:prepare(sql)
     stmt:reset():bind(book_id):step()

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -73,7 +73,7 @@ local function DeleteFileBook(path)
 
     local sql = [[
             DELETE FROM books_impl
-            WHERE book_id = :book_id
+            WHERE id = ?
         ]]
     local stmt = pocketbookDbConn:prepare(sql)
     stmt:reset():bind(book_id):step()

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -111,7 +111,7 @@ function PocketbookSync:prepareSync()
 end
 
 function PocketbookSync:getBookId(folder, file)
-    local cacheKey = data.folder .. data.file
+    local cacheKey = folder .. file
 
     if not bookIds[cacheKey] then
         local sql = [[

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -66,7 +66,7 @@ end
 
 local function DeleteFileBook(path)
     local folder, file = getFolderFile(path)
-    local book_id = getBookId(data.folder, data.file)
+    local book_id = getBookId(folder, file)
     if book_id == nil then
         return
     end

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -29,7 +29,7 @@ local function GetCurrentProfileId()
     end
 end
 
-function getFolderFile(path)
+function GetFolderFile(path)
     local folder, file = util.splitFilePathName(path)
     local folderTrimmed = folder:match("(.*)/")
     if folderTrimmed ~= nil then
@@ -38,7 +38,7 @@ function getFolderFile(path)
     return folder, file
 end
 
-function getBookId(folder, file)
+function GetBookId(folder, file)
     local cacheKey = folder .. file
 
     if not bookIds[cacheKey] then
@@ -65,8 +65,8 @@ function getBookId(folder, file)
 end
 
 local function DeleteFileBook(path)
-    local folder, file = getFolderFile(path)
-    local book_id = getBookId(folder, file)
+    local folder, file = GetFolderFile(path)
+    local book_id = GetBookId(folder, file)
     if book_id == nil then
         return
     end
@@ -103,7 +103,7 @@ function PocketbookSync:prepareSync()
         return nil
     end
 
-    local folder, file = getFolderFile(self.view.document.file)
+    local folder, file = GetFolderFile(self.view.document.file)
     if not folder or folder == "" or not file or file == "" then
         logger.info("Pocketbook Sync: No folder/file found for " .. self.view.document.file)
         return nil
@@ -150,7 +150,7 @@ function PocketbookSync:doSync(data)
         return
     end
 
-    local book_id = getBookId(data.folder, data.file)
+    local book_id = GetBookId(data.folder, data.file)
     local sql = [[
             REPLACE INTO books_settings
             (bookid, profileid, cpage, npage, completed, opentime)

--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -190,6 +190,13 @@ function PocketbookSync:onEndOfBook()
 end
 
 function PocketbookSync:onSuspend()
+    logger.dbg("PocketbookSync: onSuspend triggered")
+    
+    -- Call PageSnapshot ONLY here - this is the right place for screen capture
+    local snapshot_success, snapshot_err = pcall(inkview.PageSnapshot)
+    if not snapshot_success then
+        logger.warn("PocketbookSync: PageSnapshot failed: " .. tostring(snapshot_err))
+    end
     self:sync()
 end
 


### PR DESCRIPTION
This is a bit of a hack with patching FileManager function, but the advantage is that it works for the file deletion called from any place in the code — e.g. after the book is finished or directly in the file browser.

Tested on my PB Inkpad Color 3.