### PR TITLE
add support for database version 2 devices

### DIFF
--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -9,10 +9,29 @@ local _ = require("gettext")
 local logger = require("logger")
 local util = require("util")
 local SQ3 = require("lua-ljsqlite3/init")
-local pocketbookDbConn = SQ3.open("/mnt/ext1/system/explorer-3/explorer-3.db")
 local ffi = require("ffi")
 local inkview = ffi.load("inkview")
 local bookIds = {}
+
+local util = require("util")
+local pocketbookDbConn = nil
+local pocketbookDbVersion = 0
+
+for version = 2,3 do
+    local dbPath = "/mnt/ext1/system/explorer-" .. version .. "/explorer-" .. version .. ".db"
+    if util.pathExists(dbPath) then
+        logger.dbg("using PocketBook database version " .. version)
+        pocketbookDbConn = SQ3.open(dbPath)
+        pocketbookDbVersion = version
+        break
+    end
+end
+
+if pocketbookDbConn == nil then
+    logger.error("could not find or open PocketBook database - aborting")
+    return { disabled = true, }
+end
+
 
 -- wait for database locks for up to 1 second before raising an error
 pocketbookDbConn:set_busy_timeout(1000)
@@ -102,14 +121,26 @@ function PocketbookSync:doSync(data)
     local cacheKey = data.folder .. data.file
 
     if not bookIds[cacheKey] then
-        local sql = [[
-            SELECT book_id
-            FROM files
-            WHERE
-                folder_id = (SELECT id FROM folders WHERE name = ? LIMIT 1)
-            AND filename = ?
-            LIMIT 1
-        ]]
+        local sql = ""
+        if pocketbookDbVersion == 2 then
+            sql = [[
+                SELECT id
+                FROM books
+                WHERE
+                    foldername = ? AND filename = ?
+                LIMIT 1
+            ]]
+        else
+            -- pocketBookDbVersion == 3
+            sql = [[
+                SELECT book_id
+                FROM files
+                WHERE
+                    folder_id = (SELECT id FROM folders WHERE name = ? LIMIT 1)
+                AND filename = ?
+                LIMIT 1
+            ]]
+        end
         local stmt = pocketbookDbConn:prepare(sql)
         local row = stmt:reset():bind(data.folder, data.file):step()
         stmt:close()


### PR DESCRIPTION
Older devices like the PocketBook Touch Lux (623) use an earlier database scheme version 2 than the already supported version 3. The database schemes are much alike and only one query needs a little adjustment. I have attached the SQL making up the database scheme of [explorer-2.db.sql](https://github.com/user-attachments/files/25241484/explorer-2.db.sql).

The change was tested successfully on my PocketBook Touch Lux. Unfortunately I have no other PocketBook devices to test with.
