### PR TITLE
Always use the most recent database version

### DIFF
--- a/pocketbooksync.koplugin/main.lua
+++ b/pocketbooksync.koplugin/main.lua
@@ -16,7 +16,7 @@ local inkview = ffi.load("inkview")
 local bookIds = {}
 
 local function openPocketbookDB()
-    for version = 2, 3 do
+    for version = 3, 2, -1 do
         local dbPath = "/mnt/ext1/system/explorer-" .. version .. "/explorer-" .. version .. ".db"
         if util.pathExists(dbPath) then
             logger.dbg("Pocketbook Sync: Using database version " .. version)


### PR DESCRIPTION
On my Pocketbook Inkpad, I have both explorer-2.db and explorer-3.db database files. It was probably the result of a firmware update that kept the old database when upgrading it. (the last modification date for explorer-2.db is 2017...)

With this change we look for the most recent version of the database file first.